### PR TITLE
Fixed an error with OpenMSX 20 - Update emulator_interface.py

### DIFF
--- a/msx/emulator_interface.py
+++ b/msx/emulator_interface.py
@@ -308,7 +308,7 @@ class Emulator:
         # Send commands and get replies
         self.output(True, f'')  # needed to synchronize responses from the emulator
 
-        self.proc.stdin.write(f'<command>set renderer SDL</command>{endline}')
+        self.proc.stdin.write(f'<command>set renderer SDLGL-PP</command>{endline}')
         self.output(True, 'Showing screen')
 
         self.proc.stdin.write('<command>set throttle off</command>' + endline)


### PR DESCRIPTION
New OpenMSX 20 removed "SDL" renderer and uses "SDLGL-PP" renderer. Using the old file gives you an error and the virtual MSX won't start. The old file works with older openMSX versions, but not with versions 20+ onwards.

Source for information:
https://raw.githubusercontent.com/openMSX/openMSX/RELEASE_20_0/doc/release-notes.txt
